### PR TITLE
Refactor loadNotes method to support NotesLoader interface

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="GradleMigrationSettings" migrationVersion="1" />
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,6 +53,7 @@ dependencies {
     implementation(libs.androidx.compose.navigation)
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.firebase.dataconnect)
+    implementation(libs.androidx.runtime.livedata)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/src/main/java/luke/koz/notepad/navigation/presentation/NavHost.kt
+++ b/app/src/main/java/luke/koz/notepad/navigation/presentation/NavHost.kt
@@ -10,6 +10,7 @@ import luke.koz.notepad.notes_inspect.presentation.NotesInspectScreen
 import luke.koz.notepad.notes_inspect.presentation.NotesInspectScreenRoute
 import luke.koz.notepad.notes_list.presentation.NotesScreen
 import luke.koz.notepad.notes_list.presentation.NotesScreenRoute
+import luke.koz.notepad.notes_modify.presentation.NotesInsertEditScreenRoute
 
 @Composable
 fun ApplicationNavHost(modifier: Modifier = Modifier) {
@@ -24,6 +25,10 @@ fun ApplicationNavHost(modifier: Modifier = Modifier) {
         composable<NotesInspectScreenRoute> {
             val args = it.toRoute<NotesInspectScreenRoute>()
             NotesInspectScreen(modifier = modifier, uuidAsString = args.uuidAsString)
+        }
+        composable<NotesInsertEditScreenRoute> {
+            val args = it.toRoute<NotesInsertEditScreenRoute>()
+
         }
     }
 }

--- a/app/src/main/java/luke/koz/notepad/notes_list/domain/NotesViewModel.kt
+++ b/app/src/main/java/luke/koz/notepad/notes_list/domain/NotesViewModel.kt
@@ -1,36 +1,25 @@
 package luke.koz.notepad.notes_list.domain
 
 import android.content.Context
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharingStarted
-import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.stateIn
-import kotlinx.serialization.json.Json
 import luke.koz.notepad.notes_list.model.NotesDataClass
 import luke.koz.notepad.notes_list.model.NotesListResponse
+import luke.koz.notepad.utils.domain.DefaultNotesLoader
+import luke.koz.notepad.utils.domain.NotesLoader
 
-class NotesViewModel () : ViewModel () {
+class NotesViewModel : ViewModel () {
 
+    private val _notesLoader: NotesLoader = DefaultNotesLoader()
     private val _contentMaxLength : Int = 100
     private val _noteContent  = MutableStateFlow<String?>(null)
 
-/*
-    val displayedContent: StateFlow<String> = _noteContent
-        .map { content ->
-            content?.let {
-                if (it.length > _contentMaxLength) {
-                    it.take(_contentMaxLength) + "..."
-                } else {
-                    it
-                }
-            } ?: ""
-        }
-        .stateIn(viewModelScope, SharingStarted.Lazily, "")
-*/
+    private val _notes = MutableLiveData<NotesListResponse>()
+    val notes: LiveData<NotesListResponse> get() = _notes
 
     /**
      * Function to truncate note to length size of given int.
@@ -52,9 +41,9 @@ class NotesViewModel () : ViewModel () {
         _noteContent.value = updatedContent
     }
 
-    fun loadNotes(context: Context, fileName: String): NotesListResponse {
-        val jsonString = context.assets.open(fileName).bufferedReader().use { it.readText() }
-        return Json.decodeFromString(jsonString)
+    fun loadNotes(context: Context, fileName: String) {
+        val notesListResponse = _notesLoader.loadNotes(context, fileName)
+        _notes.value = notesListResponse
     }
 
 }

--- a/app/src/main/java/luke/koz/notepad/notes_list/presentation/NotesScreen.kt
+++ b/app/src/main/java/luke/koz/notepad/notes_list/presentation/NotesScreen.kt
@@ -1,17 +1,31 @@
 package luke.koz.notepad.notes_list.presentation
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Add
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavHostController
 import kotlinx.serialization.Serializable
 import luke.koz.notepad.notes_inspect.presentation.NotesInspectScreenRoute
 import luke.koz.notepad.notes_list.domain.NotesViewModel
+import luke.koz.notepad.notes_list.model.NotesDataClass
 import luke.koz.notepad.utils.presentation.ScaffoldTopAppBar
 
 @Serializable object NotesScreenRoute
@@ -27,18 +41,43 @@ fun NotesScreen(modifier: Modifier = Modifier, navController: NavHostController)
                 modifier = modifier,
                 scrollBehavior = null
             )
+        },
+        floatingActionButton = {
+            FloatingActionButton(
+                onClick = {
+//                    navController.navigate()
+                }
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Add,
+                    contentDescription = "Add note button"
+                )
+            }
         }
     ) { innerPadding ->
         val notesViewModel: NotesViewModel = viewModel()
         val context = LocalContext.current
-        val listOfNotes = notesViewModel.loadNotes(context, "notes.json").notesResponse
-        val onCardClickNavigate : (String) -> Unit = { uuidAsString ->
-            navController.navigate(NotesInspectScreenRoute(uuidAsString))
+
+        LaunchedEffect(Unit) {
+            notesViewModel.loadNotes(context, "notes.json")
         }
+        val notesListResponse by notesViewModel.notes.observeAsState()
+
         //todo this could be remade into grid of item for flavour and make it look like other apps
-        Column(modifier.padding(innerPadding)) {
-            listOfNotes.forEach() { note ->
-                NotesSingleNote(modifier, note) { onCardClickNavigate(note.id.toString()) }
+        Column(modifier = Modifier.padding(innerPadding)) {
+            notesListResponse?.let { response ->
+                response.notesResponse.forEach { note ->
+                    val onCardClickNavigate: (String) -> Unit = { uuidAsString ->
+                        navController.navigate(NotesInspectScreenRoute(uuidAsString))
+                    }
+                    NotesSingleNote(
+                        modifier = Modifier.fillMaxWidth().padding(8.dp),
+                        note = note,
+                        onClick = { onCardClickNavigate(note.id.toString()) }
+                    )
+                }
+            } ?: run {
+                Text("Loading notes...")
             }
         }
     }

--- a/app/src/main/java/luke/koz/notepad/notes_list/presentation/NotesSingleNote.kt
+++ b/app/src/main/java/luke/koz/notepad/notes_list/presentation/NotesSingleNote.kt
@@ -24,7 +24,7 @@ fun NotesSingleNote(
     modifier: Modifier = Modifier,
     note: NotesDataClass,
     truncateNoteBoolean : Boolean = true,
-    onClick: () -> Unit,
+    onClick: (() -> Unit)?,
 ) {
     val notesViewModel: NotesViewModel = viewModel()
     // TODO these should be passed by reference but this is future me problem
@@ -32,12 +32,17 @@ fun NotesSingleNote(
     val truncatedNoteContent by notesViewModel
         .truncateNoteContent(note)
         .collectAsState("")
-//    val onCardClick : (NavController) -> Unit
     Card(
         modifier = modifier
             .padding(8.dp)
             .fillMaxWidth()
-            .clickable { onClick() }
+            .let {
+                if (onClick != null) {
+                    it.clickable { onClick() }
+                } else {
+                    it
+                }
+            }
     ) {
         NotesSingleNoteContent(
             modifier = modifier,

--- a/app/src/main/java/luke/koz/notepad/notes_modify/domain/NoteInputEditViewModel.kt
+++ b/app/src/main/java/luke/koz/notepad/notes_modify/domain/NoteInputEditViewModel.kt
@@ -1,0 +1,19 @@
+package luke.koz.notepad.notes_modify.domain
+
+import android.content.Context
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import luke.koz.notepad.notes_list.model.NotesListResponse
+import luke.koz.notepad.utils.domain.DefaultNotesLoader
+import luke.koz.notepad.utils.domain.NotesLoader
+
+class NoteInputEditViewModel : ViewModel() {
+    private val _notesLoader: NotesLoader = DefaultNotesLoader()
+    private val _notes = MutableLiveData<NotesListResponse>()
+    val notes: LiveData<NotesListResponse> get() = _notes
+    fun loadNotes(context: Context, fileName: String) {
+        val notesListResponse = _notesLoader.loadNotes(context, fileName)
+        _notes.value = notesListResponse
+    }
+}

--- a/app/src/main/java/luke/koz/notepad/notes_modify/presentation/NoteInputEditTopAppBar.kt
+++ b/app/src/main/java/luke/koz/notepad/notes_modify/presentation/NoteInputEditTopAppBar.kt
@@ -1,0 +1,86 @@
+package luke.koz.notepad.notes_modify.presentation
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Done
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import luke.koz.notepad.R
+import luke.koz.notepad.ui.theme.NotepadTheme
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun NoteInputEditTopAppBar(
+    modifier: Modifier = Modifier,
+    onBackClick: () -> Unit,
+    onUndoClick: () -> Unit,
+    onRedoClick: () -> Unit,
+    onConfirmClick: () -> Unit
+) {
+    CenterAlignedTopAppBar(
+        title = {},
+        modifier = modifier,
+        navigationIcon = {
+            IconButton(onClick = onBackClick) {
+                Icon(
+                    imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                    contentDescription = "Back",
+                )
+            }
+        },
+        actions = {
+            Row(
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.padding(end = 8.dp) // Adjust padding as needed
+            ) {
+                IconButton(onClick = onUndoClick) {
+                    Icon(
+                        painter = painterResource(R.drawable.baseline_undo_24),
+                        contentDescription = "Undo",
+                    )
+                }
+                IconButton(onClick = onRedoClick) {
+                    Icon(
+                        painter = painterResource(R.drawable.baseline_undo_24),
+                        contentDescription = "Redo",
+                        modifier = Modifier.graphicsLayer(scaleX = -1f)
+                    )
+                }
+                IconButton(onClick = onConfirmClick) {
+                    Icon(
+                        imageVector = Icons.Default.Done,
+                        contentDescription = "Confirm and save"
+                    )
+                }
+            }
+        }
+    )
+}
+
+@Preview
+@Composable
+private fun NoteInputEditTopAppBarPreview() {
+    NotepadTheme {
+        NoteInputEditTopAppBar(
+            modifier = Modifier,
+            onBackClick = {},
+            onUndoClick = {},
+            onRedoClick = {},
+            onConfirmClick = {}
+        )
+    }
+}

--- a/app/src/main/java/luke/koz/notepad/notes_modify/presentation/NoteInputForm.kt
+++ b/app/src/main/java/luke/koz/notepad/notes_modify/presentation/NoteInputForm.kt
@@ -1,0 +1,67 @@
+package luke.koz.notepad.notes_modify.presentation
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.tooling.preview.Preview
+import luke.koz.notepad.R
+import luke.koz.notepad.notes_list.model.NoteStatus
+import luke.koz.notepad.notes_list.model.NotesDataClass
+import luke.koz.notepad.notes_list.model.Priority
+import luke.koz.notepad.ui.theme.NotepadTheme
+import java.util.Currency
+import java.util.Locale
+
+@Composable
+fun ItemInputForm(
+    modifier: Modifier = Modifier,
+    noteEntry : NotesDataClass
+) {
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.padding_medium))
+    ) {
+        OutlinedTextField(
+            value = noteEntry.title,
+            onValueChange = {  },
+            label = { Text("Item name*") },
+            colors = OutlinedTextFieldDefaults.colors(
+                focusedContainerColor = MaterialTheme.colorScheme.secondaryContainer,
+                unfocusedContainerColor = MaterialTheme.colorScheme.secondaryContainer,
+                disabledContainerColor = MaterialTheme.colorScheme.secondaryContainer,
+            ),
+            modifier = Modifier.fillMaxWidth(),
+            enabled = true,
+            singleLine = true
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun ItemInputFormPreview() {
+    val mockNote = NotesDataClass(
+        title = stringResource(R.string.mock_note1_title),
+        content = stringResource(R.string.mock_note1_content),
+        tags = listOf("meeting", "project"),
+        category = "Work",
+        priority = Priority.HIGH,
+        noteStatus = NoteStatus.DRAFT,
+        lastModifiedBy = "Luke",
+        reminderAt = System.currentTimeMillis() + 86400000 // 1 day later
+    )
+    NotepadTheme {
+        ItemInputForm(Modifier, noteEntry = mockNote)
+    }
+}

--- a/app/src/main/java/luke/koz/notepad/notes_modify/presentation/NotesInsertEditBody.kt
+++ b/app/src/main/java/luke/koz/notepad/notes_modify/presentation/NotesInsertEditBody.kt
@@ -1,0 +1,9 @@
+package luke.koz.notepad.notes_modify.presentation
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+@Composable
+fun NotesInsertEditBody(modifier: Modifier = Modifier, uuidAsString : String? = null) {
+
+}

--- a/app/src/main/java/luke/koz/notepad/notes_modify/presentation/NotesInsertEditScreen.kt
+++ b/app/src/main/java/luke/koz/notepad/notes_modify/presentation/NotesInsertEditScreen.kt
@@ -1,0 +1,68 @@
+package luke.koz.notepad.notes_modify.presentation
+
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.calculateEndPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.tooling.preview.Preview
+import kotlinx.serialization.Serializable
+import luke.koz.notepad.ui.theme.NotepadTheme
+import luke.koz.notepad.utils.presentation.ScaffoldTopAppBar
+
+@Serializable data class NotesInsertEditScreenRoute (val uuidAsString: String)
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun NotesInsertEditScreen(modifier: Modifier = Modifier, uuidAsString : String?) {
+    Scaffold (
+        topBar = {
+            NoteInputEditTopAppBar(
+                modifier = TODO(),
+                onBackClick = TODO(),
+                onUndoClick = TODO(),
+                onRedoClick = TODO(),
+                onConfirmClick = TODO()
+            )
+        },
+        floatingActionButton = {
+            FloatingActionButton(
+                onClick = {},
+                shape = MaterialTheme.shapes.medium,
+                modifier = Modifier
+                    .padding(
+                        end = WindowInsets.safeDrawing.asPaddingValues()
+                            .calculateEndPadding(LocalLayoutDirection.current)
+                    )
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Edit,
+                    contentDescription = "Edit/insert note",
+                )
+            }
+        }
+    ) {
+        NotesInsertEditBody(modifier = modifier.padding(it), uuidAsString = uuidAsString ?: null)
+    }
+}
+
+@Preview
+@Composable
+private fun NotesInsertEditScreenPreview() {
+    NotepadTheme {
+        NotesInsertEditScreen(modifier = Modifier, uuidAsString = null)
+    }
+}

--- a/app/src/main/java/luke/koz/notepad/utils/domain/NotesLoader.kt
+++ b/app/src/main/java/luke/koz/notepad/utils/domain/NotesLoader.kt
@@ -1,0 +1,16 @@
+package luke.koz.notepad.utils.domain
+
+import android.content.Context
+import kotlinx.serialization.json.Json
+import luke.koz.notepad.notes_list.model.NotesListResponse
+
+interface NotesLoader {
+    fun loadNotes(context: Context, fileName: String): NotesListResponse
+}
+
+class DefaultNotesLoader : NotesLoader {
+    override fun loadNotes(context: Context, fileName: String): NotesListResponse {
+        val jsonString = context.assets.open(fileName).bufferedReader().use { it.readText() }
+        return Json.decodeFromString(jsonString) // Assuming Json is defined elsewhere
+    }
+}

--- a/app/src/main/res/drawable/baseline_undo_24.xml
+++ b/app/src/main/res/drawable/baseline_undo_24.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:autoMirrored="true" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M12.5,8c-2.65,0 -5.05,0.99 -6.9,2.6L2,7v9h9l-3.62,-3.62c1.39,-1.16 3.16,-1.88 5.12,-1.88 3.54,0 6.55,2.31 7.6,5.5l2.37,-0.78C21.08,11.03 17.15,8 12.5,8z"/>
+    
+</vector>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="padding_small">8dp</dimen>
+    <dimen name="padding_medium">16dp</dimen>
+    <dimen name="padding_large">20dp</dimen>
+    <dimen name="padding_extra_large">32dp</dimen>
+</resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,7 @@ activityCompose = "1.9.2"
 composeBom = "2024.04.01"
 navigationCompose = "2.8.0-beta06"
 firebaseDataconnect = "16.0.0-beta01"
+runtimeLivedata = "1.7.3"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -29,6 +30,7 @@ androidx-material3 = { group = "androidx.compose.material3", name = "material3" 
 androidx-compose-navigation = { group = "androidx.navigation", name = "navigation-compose", version.ref="navigationCompose"}
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version = "1.6.3" }
 firebase-dataconnect = { group = "com.google.firebase", name = "firebase-dataconnect", version.ref = "firebaseDataconnect" }
+androidx-runtime-livedata = { group = "androidx.compose.runtime", name = "runtime-livedata", version.ref = "runtimeLivedata" }
 
 
 [plugins]


### PR DESCRIPTION
- Remade `loadNotes` method to implement the `NotesLoader` interface.
- Introduced a helper class `DefaultNotesLoader` to be invoked within the ViewModel.
- Updated the UI layer to work with these changes using the `observeAsState` method.

The goal of this change was to reduce redundancy and improve code reusability.